### PR TITLE
Rename entry point from /myst to /myst-build.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Jupyter server extension that serves and proxies static MyST websites.
 
 ## Features
 
-- **Path-based routing**: Access MyST projects at `/myst/<project-path>/`
+- **Path-based routing**: Access MyST projects at `/myst-build/<project-path>/`
 - **On-demand building**: Automatically builds MyST sites when first accessed
 - **Rebuild support**: Trigger rebuilds with `?rebuild=1` query parameter
 - **Multiple projects**: Serve different MyST projects from subdirectories
@@ -24,16 +24,16 @@ pip install jupyter-myst-build-proxy
 
 ### Basic Usage
 
-With a jupyter application running, visit `/myst/<project-path>/` where `<project-path>` is a directory containing a MyST project (with `myst.yml`).
+With a jupyter application running, visit `/myst-build/<project-path>/` where `<project-path>` is a directory containing a MyST project (with `myst.yml`).
 
 Example 1: Jupyter server on localhost
 ```
-http://localhost:8888/myst/my-documentation/
+http://localhost:8888/myst-build/my-documentation/
 ```
 
 Example 2: Jupyter server on a JupyterHub
 ```
-https://jupyterhub.example.edu/user/username/myst/my-website/
+https://jupyterhub.example.edu/user/username/myst-build/my-website/
 ```
 
 ### Configuration
@@ -45,19 +45,19 @@ Set the default directory using the `JUPYTER_MYST_BUILD_PROXY_DIR` environment v
 To force a rebuild of a MyST site, add `?rebuild=1` to any page URL:
 
 ```
-http://localhost:8888/myst/my-documentation/?rebuild=1
+http://localhost:8888/myst-build/my-documentation/?rebuild=1
 ```
 
 This will delete the `_build/html` directory and regenerate the site.
 
 ## How It Works
 
-1. When you access `/myst/<project-path>/`, the extension:
+1. When you access `/myst-build/<project-path>/`, the extension:
    - Checks if `<project-path>/myst.yml` exists
    - If the site hasn't been built, runs `myst build --html --ci` with the appropriate `BASE_URL`
    - Serves the static HTML from `<project-path>/_build/html/`
 
-2. The extension uses path-based routing to ensure all assets and navigation links work correctly with the `/myst/<project-path>/` prefix.
+2. The extension uses path-based routing to ensure all assets and navigation links work correctly with the `/myst-build/<project-path>/` prefix.
 
 ## Requirements
 

--- a/jupyter_myst_build_proxy/no_myst_error.html
+++ b/jupyter_myst_build_proxy/no_myst_error.html
@@ -74,7 +74,7 @@
         <p>To use MyST, you need to:</p>
         <ol>
             <li>Create a MyST project with <code>myst init</code></li>
-            <li>Or visit <code>/myst/&lt;project-path&gt;/</code> to specify a different project</li>
+            <li>Or visit <code>/myst-build/&lt;project-path&gt;/</code> to specify a different project</li>
         </ol>
     </div>
 </body>

--- a/jupyter_myst_build_proxy/static_server.py
+++ b/jupyter_myst_build_proxy/static_server.py
@@ -169,10 +169,10 @@ class MystHTTPRequestHandler(SimpleHTTPRequestHandler):
         jupyter_prefix = self.jupyter_base_url.rstrip("/")
 
         if os.path.abspath(myst_dir) == os.path.abspath(self.default_directory):
-            base_url = f"{jupyter_prefix}/myst"
+            base_url = f"{jupyter_prefix}/myst-build"
         else:
             rel_path = os.path.relpath(myst_dir, self.default_directory)
-            base_url = f"{jupyter_prefix}/myst/{rel_path}"
+            base_url = f"{jupyter_prefix}/myst-build/{rel_path}"
 
         log.debug(f"base_url={base_url}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ Repository = "https://github.com/ryanlovett/jupyter-myst-build-proxy"
 Issues = "https://github.com/ryanlovett/jupyter-myst-build-proxy/issues"
 
 [project.entry-points."jupyter_serverproxy_servers"]
-myst = "jupyter_myst_build_proxy:setup_myst"
+myst-build = "jupyter_myst_build_proxy:setup_myst"
 
 [build-system]
 requires = ["setuptools>=45", "wheel"]

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ The tests spin up a local JupyterHub instance and verify:
 
 1. **Basic MyST build**: MyST sites build correctly and serve content
 2. **Asset loading**: JS/CSS assets load from the correct paths (with `/user/{username}/` prefix)
-3. **Edge case - username "myst"**: Correctly handles the case where a username is "myst" (path becomes `/user/myst/myst/...`)
+3. **Edge case - username "myst"**: Correctly handles the case where a username is "myst-build" (path becomes `/user/myst-build/myst-build/...`)
 4. **Deep project paths**: Projects in subdirectories like `proj/courses/stat134/fall-2025/` work correctly
 
 ## Setup
@@ -67,14 +67,14 @@ pytest test_jupyterhub_integration.py::test_basic_myst_build -v -s
    - `DummyAuthenticator`: Allows login with any username/password (for testing)
    - `SimpleLocalProcessSpawner`: Spawns servers as local processes (no Docker needed)
    - Localhost binding on port 8000
-   - Allowed test users: `testuser`, `myst`, `alice`, `bob`
+   - Allowed test users: `testuser`, `myst-build`, `alice`, `bob`
 
 2. **Test Flow**:
    - Start JupyterHub in the background
    - Login as a test user
    - Spawn their single-user server
    - Copy the test MyST site to their home directory
-   - Access `/user/{username}/myst/test-myst-site/`
+   - Access `/user/{username}/myst-build/test-myst-site/`
    - Wait for the site to build
    - Verify the HTML content and asset paths
    - Clean up

--- a/tests/test_jupyterhub_integration.py
+++ b/tests/test_jupyterhub_integration.py
@@ -5,7 +5,7 @@ These tests spin up a local JupyterHub instance and verify that:
 1. MyST sites build correctly
 2. Assets load from the correct paths (with /user/{username}/ prefix)
 3. Navigation links are rewritten correctly
-4. Edge cases like username "myst" work correctly
+4. Edge cases like username "myst-build" work correctly
 """
 
 import os
@@ -21,7 +21,7 @@ from pathlib import Path
 JUPYTERHUB_URL = "http://127.0.0.1:8000"
 JUPYTERHUB_CONFIG = Path(__file__).parent / "jupyterhub_config.py"
 TEST_SITE_DIR = Path(__file__).parent / "test-site"
-TEST_USERS = ["testuser", "myst", "alice"]
+TEST_USERS = ["testuser", "myst-build", "alice"]
 
 
 class JupyterHubInstance:
@@ -220,7 +220,7 @@ def test_basic_myst_build(jupyterhub):
     test_site = setup_test_site(username)
     
     # Access the MyST proxy endpoint
-    myst_url = f"{JUPYTERHUB_URL}/user/{username}/myst/test-myst-site/"
+    myst_url = f"{JUPYTERHUB_URL}/user/{username}/myst-build/test-myst-site/"
     print(f"Accessing: {myst_url}")
     
     response = session.get(myst_url, timeout=60)
@@ -244,8 +244,8 @@ def test_basic_myst_build(jupyterhub):
     
     # Print asset path info for debugging
     html = response.text
-    if f"/user/{username}/myst/" in html:
-        print("✓ Asset paths are correctly prefixed with user/username/myst/")
+    if f"/user/{username}/myst-build/" in html:
+        print("✓ Asset paths are correctly prefixed with user/username/myst-build/")
     elif 'href="/build/' in html:
         print("⚠ Asset paths are NOT prefixed (using /build/ directly)")
     
@@ -255,8 +255,8 @@ def test_basic_myst_build(jupyterhub):
 
 
 def test_username_myst(jupyterhub):
-    """Test that username 'myst' works correctly (edge case)"""
-    username = "myst"
+    """Test that username 'myst-build' works correctly (edge case)"""
+    username = "myst-build"
     
     # Login and spawn server
     session = login_and_get_cookie(username)
@@ -266,8 +266,8 @@ def test_username_myst(jupyterhub):
     test_site = setup_test_site(username)
     
     # Access the MyST proxy endpoint
-    # URL should be /user/myst/myst/test-myst-site/
-    myst_url = f"{JUPYTERHUB_URL}/user/{username}/myst/test-myst-site/"
+    # URL should be /user/myst-build/myst-build/test-myst-site/
+    myst_url = f"{JUPYTERHUB_URL}/user/{username}/myst-build/test-myst-site/"
     print(f"Accessing: {myst_url}")
     
     response = session.get(myst_url, timeout=60)
@@ -286,7 +286,7 @@ def test_username_myst(jupyterhub):
     
     # Verify assets paths are correct (should not confuse the two "myst"s)
     html = response.text
-    assert f"/user/{username}/myst/" in html or f'href="build/' in html
+    assert f"/user/{username}/myst-build/" in html or f'href="build/' in html
     
     # Clean up
     if test_site.exists():
@@ -305,7 +305,7 @@ def test_asset_loading(jupyterhub):
     test_site = setup_test_site(username)
     
     # Access the MyST site
-    myst_url = f"{JUPYTERHUB_URL}/user/{username}/myst/test-myst-site/"
+    myst_url = f"{JUPYTERHUB_URL}/user/{username}/myst-build/test-myst-site/"
     
     # Wait for build
     max_wait = 60
@@ -376,7 +376,7 @@ def test_deep_subdirectory_paths(jupyterhub):
     print(f"myst.yml exists: {(deep_path / 'myst.yml').exists()}")
     
     # Access the MyST proxy endpoint with deep path
-    myst_url = f"{JUPYTERHUB_URL}/user/{username}/myst/courses/fall/stat159/"
+    myst_url = f"{JUPYTERHUB_URL}/user/{username}/myst-build/courses/fall/stat159/"
     print(f"Accessing: {myst_url}")
     
     response = session.get(myst_url, timeout=60)
@@ -395,7 +395,7 @@ def test_deep_subdirectory_paths(jupyterhub):
     
     # Verify assets paths include the deep path
     html = response.text
-    assert f"/user/{username}/myst/courses/fall/stat159/" in html or f'href="build/' in html
+    assert f"/user/{username}/myst-build/courses/fall/stat159/" in html or f'href="build/' in html
     
     # Clean up - remove the entire courses directory
     courses_dir = home_dir / "courses"
@@ -440,7 +440,7 @@ def test_multiple_deep_paths(jupyterhub):
     print(f"Created spring site at: {spring_path}")
     
     # Test fall site
-    fall_url = f"{JUPYTERHUB_URL}/user/{username}/myst/courses/fall/stat159/"
+    fall_url = f"{JUPYTERHUB_URL}/user/{username}/myst-build/courses/fall/stat159/"
     print(f"Accessing fall site: {fall_url}")
     
     max_wait = 60
@@ -463,7 +463,7 @@ def test_multiple_deep_paths(jupyterhub):
     assert "Test MyST Site" in fall_response.text
     
     # Test spring site
-    spring_url = f"{JUPYTERHUB_URL}/user/{username}/myst/courses/spring/stat159/"
+    spring_url = f"{JUPYTERHUB_URL}/user/{username}/myst-build/courses/spring/stat159/"
     print(f"Accessing spring site: {spring_url}")
     
     spring_response = None


### PR DESCRIPTION
At somepoint MyST's live server will enable it to be more easily proxied. When that happens some other server extension can proxy it via /myst.