### PR TITLE
Quick fix for bug when serving rendered site from root of project

### DIFF
--- a/jupyter_myst_build_proxy/static_server.py
+++ b/jupyter_myst_build_proxy/static_server.py
@@ -59,7 +59,7 @@ class MystHTTPRequestHandler(SimpleHTTPRequestHandler):
 
         # Try to find myst.yml by traversing path segments from longest to shortest
         # This allows for deeper paths like /proj/project1/website
-        for i in range(len(parts), 0, -1):
+        for i in range(len(parts), -1, -1):
             potential_myst_dir = os.path.join(self.default_directory, *parts[:i])
             potential_myst_dir = os.path.abspath(potential_myst_dir)
             log.debug(f"_parse_path: Checking {potential_myst_dir}/myst.yml")


### PR DESCRIPTION
When serving rendered site from root of project, assets (e.g., stylesheets) were not being served properly. This is a quick fix for an immediate need; I didn't have time to look carefully enough at the code to determine whether this is the best way to address this issue. I'm sharing this now only in case it might be helpful to others.